### PR TITLE
Validate the availability and executability of the fakeroot binary

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,11 @@
             <artifactId>collections-generic</artifactId>
             <version>4.01</version>
         </dependency>
+        <dependency>
+            <groupId>de.richtercloud</groupId>
+            <artifactId>execution-tools</artifactId>
+            <version>1.4</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/net/sf/debianmaven/PackageMojo.java
+++ b/src/main/java/net/sf/debianmaven/PackageMojo.java
@@ -19,6 +19,8 @@ import java.util.Set;
 import java.util.Vector;
 import java.util.zip.GZIPOutputStream;
 
+import de.richtercloud.execution.tools.BinaryUtils;
+import de.richtercloud.execution.tools.BinaryValidationException;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.collections15.MultiMap;
 import org.apache.commons.collections15.multimap.MultiHashMap;
@@ -486,6 +488,12 @@ public class PackageMojo extends AbstractDebianMojo
 
 	private void generatePackage() throws IOException, MojoExecutionException
 	{
+		try {
+			BinaryUtils.validateBinary("fakeroot", "fakeroot");
+		}catch(BinaryValidationException ex) {
+			throw new MojoExecutionException("The binary fakeroot is not available or cannot be executed",
+					ex);
+		}
 		runProcess(new String[]{"fakeroot", "--", "dpkg-deb", "--build", stageDir.toString(), getPackageFile().toString()}, true);
 	}
 


### PR DESCRIPTION
Validate the availability and executability of the fakeroot binary in order to avoid the (rather) cryptic error message `java.io.IOException: Cannot run program "fakeroot" (in directory "."): error=2, No such file or directory -> [Help 1]`

It's not impossible to figure out what's wrong, but using my mini-library provides better feedback imo.